### PR TITLE
Added the possibility to define constructor parameter values directly…

### DIFF
--- a/examples/ContainerConfig.php
+++ b/examples/ContainerConfig.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WoohooLabs\Zen\Examples;
 
 use WoohooLabs\Zen\Config\AbstractContainerConfig;
+use WoohooLabs\Zen\Config\EntryPoint\ClassEntryPoint;
 use WoohooLabs\Zen\Config\EntryPoint\WildcardEntryPoint;
 use WoohooLabs\Zen\Config\Hint\DefinitionHint;
 use WoohooLabs\Zen\Config\Hint\WildcardHint;
@@ -11,6 +12,7 @@ use WoohooLabs\Zen\Examples\Service\AnimalService;
 use WoohooLabs\Zen\Examples\Service\AnimalServiceInterface;
 use WoohooLabs\Zen\Examples\Service\PlantService;
 use WoohooLabs\Zen\Examples\Service\PlantServiceInterface;
+use WoohooLabs\Zen\Examples\Utils\NatureUtil;
 
 class ContainerConfig extends AbstractContainerConfig
 {
@@ -18,6 +20,7 @@ class ContainerConfig extends AbstractContainerConfig
     {
         return [
             new WildcardEntryPoint(__DIR__ . "/Controller"),
+            new ClassEntryPoint(NatureUtil::class, ['humansEnabled' => true]),
         ];
     }
 

--- a/examples/Utils/NatureUtil.php
+++ b/examples/Utils/NatureUtil.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace WoohooLabs\Zen\Examples\Utils;
+
+class NatureUtil
+{
+    /**
+     * @var AnimalUtil
+     */
+    private $animalUtil;
+
+    /**
+     * @var PlantUtil
+     */
+    private $plantUtil;
+
+    /**
+     * @var bool
+     */
+    private $humansEnabled;
+
+    /**
+     * NatureUtil constructor.
+     *
+     * @param AnimalUtil $animalUtil
+     * @param PlantUtil $plantUtil
+     * @param bool $humansEnabled
+     */
+    public function __construct(AnimalUtil $animalUtil, PlantUtil $plantUtil, bool $humansEnabled)
+    {
+        $this->animalUtil = $animalUtil;
+        $this->plantUtil = $plantUtil;
+        $this->humansEnabled = $humansEnabled;
+    }
+
+}

--- a/examples/Utils/NatureUtil.php
+++ b/examples/Utils/NatureUtil.php
@@ -32,5 +32,4 @@ class NatureUtil
         $this->plantUtil = $plantUtil;
         $this->humansEnabled = $humansEnabled;
     }
-
 }

--- a/src/Config/EntryPoint/ClassEntryPoint.php
+++ b/src/Config/EntryPoint/ClassEntryPoint.php
@@ -15,14 +15,20 @@ class ClassEntryPoint implements EntryPointInterface
      */
     private $autoloaded;
 
-    public static function create(string $className): ClassEntryPoint
+    /**
+     * @var array
+     */
+    private $constructorParams;
+
+    public static function create(string $className, array $constructorParams = []): ClassEntryPoint
     {
-        return new ClassEntryPoint($className);
+        return new ClassEntryPoint($className, $constructorParams);
     }
 
-    public function __construct(string $className)
+    public function __construct(string $className, array $constructorParams = [])
     {
         $this->className = $className;
+        $this->constructorParams = $constructorParams;
         $this->autoloaded = false;
     }
 
@@ -41,6 +47,24 @@ class ClassEntryPoint implements EntryPointInterface
         return [
             $this->className,
         ];
+    }
+
+    /**
+     * @param string $paramName
+     * @return bool
+     */
+    public function hasConstructorParam(string $paramName)
+    {
+        return array_key_exists($paramName, $this->constructorParams);
+    }
+
+    /**
+     * @param string $paramName
+     * @return mixed
+     */
+    public function getConstructorParam($paramName)
+    {
+        return $this->constructorParams[$paramName];
     }
 
     public function isAutoloaded(): bool


### PR DESCRIPTION
… in the container configuration.

Feel free to pull. I haven't updated the docs, nor did I add any tests.

I used the method `addOptionalConstructorArgument` of `ClassDefinition` for a constructor parameter that was explicitly defined in the container configuration. It works, but maybe we should create a new method for this purpose.

Best regards
@adriansuter