### PR TITLE
Fix deprecation warnings on PHP 8.2

### DIFF
--- a/src/AbstractCompiledContainer.php
+++ b/src/AbstractCompiledContainer.php
@@ -8,6 +8,8 @@ use Closure;
 use Psr\Container\ContainerInterface;
 use WoohooLabs\Zen\Exception\NotFoundException;
 
+use function property_exists;
+
 abstract class AbstractCompiledContainer implements ContainerInterface
 {
     /** @var array<string, object> */
@@ -34,7 +36,9 @@ abstract class AbstractCompiledContainer implements ContainerInterface
         Closure::bind(
             static function () use ($object, $properties): void {
                 foreach ($properties as $name => $value) {
-                    $object->$name = $value;
+                    if (property_exists($object, $name)) {
+                        $object->$name = $value;
+                    }
                 }
             },
             null,

--- a/src/Container/Definition/ClassDefinition.php
+++ b/src/Container/Definition/ClassDefinition.php
@@ -247,7 +247,7 @@ class ClassDefinition extends AbstractDefinition
         $code = "";
 
         if ($inline === false) {
-            $code .= "${indent}return ";
+            $code .= "{$indent}return ";
         }
 
         if ($this->isSingletonCheckEliminable($parentId) === false) {
@@ -256,7 +256,7 @@ class ClassDefinition extends AbstractDefinition
 
         if ($hasProperties) {
             $code .= "\$this->setClassProperties(\n";
-            $code .= "${indent}${tab}";
+            $code .= "{$indent}{$tab}";
         }
 
         $code .= "new \\" . $this->getClassName() . "(";
@@ -271,40 +271,40 @@ class ClassDefinition extends AbstractDefinition
             if (array_key_exists("class", $constructorArgument)) {
                 $definition = $compilation->getDefinition($constructorArgument["class"]);
 
-                $code .= "\n${constructorIndent}${tab}" . $this->compileEntryReference(
+                $code .= "\n{$constructorIndent}{$tab}" . $this->compileEntryReference(
                     $definition,
                     $compilation,
                     $constructorIndentationLevel + 1,
                     $preloadedClasses
                 ) . ",";
             } elseif (array_key_exists("value", $constructorArgument)) {
-                $code .= "\n${constructorIndent}${tab}" . $this->serializeValue($constructorArgument["value"]) . ",";
+                $code .= "\n{$constructorIndent}{$tab}" . $this->serializeValue($constructorArgument["value"]) . ",";
             }
         }
 
         if ($hasConstructorArguments) {
-            $code .= "\n${constructorIndent})";
+            $code .= "\n{$constructorIndent})";
         }
 
         if ($hasProperties) {
             $code .= ",\n";
-            $code .= "${indent}${tab}[\n";
+            $code .= "{$indent}{$tab}[\n";
             foreach ($this->properties as $propertyName => $property) {
                 if (array_key_exists("class", $property)) {
                     $definition = $compilation->getDefinition($property["class"]);
 
-                    $code .= "${indent}${tab}${tab}'$propertyName' => " . $this->compileEntryReference(
+                    $code .= "{$indent}{$tab}{$tab}'$propertyName' => " . $this->compileEntryReference(
                         $definition,
                         $compilation,
                         $indentationLevel + 2,
                         $preloadedClasses
                     ) . ",\n";
                 } elseif (array_key_exists("value", $property)) {
-                    $code .= "${indent}${tab}${tab}'$propertyName' => " . $this->serializeValue($property["value"]) . ",\n";
+                    $code .= "{$indent}{$tab}{$tab}'$propertyName' => " . $this->serializeValue($property["value"]) . ",\n";
                 }
             }
-            $code .= "${indent}${tab}]\n";
-            $code .= "${indent})";
+            $code .= "{$indent}{$tab}]\n";
+            $code .= "{$indent})";
         }
 
         if ($inline === false) {

--- a/src/Container/Definition/ReferenceDefinition.php
+++ b/src/Container/Definition/ReferenceDefinition.php
@@ -131,7 +131,7 @@ class ReferenceDefinition extends AbstractDefinition
         $code = "";
 
         if ($inline === false) {
-            $code .= "${indent}return ";
+            $code .= "{$indent}return ";
         }
 
         if ($this->isSingletonCheckEliminable($parentId) === false) {

--- a/src/Container/Definition/SelfDefinition.php
+++ b/src/Container/Definition/SelfDefinition.php
@@ -67,6 +67,6 @@ class SelfDefinition extends AbstractDefinition
             return "\$this";
         }
 
-        return "${indent}return \$this;\n";
+        return "{$indent}return \$this;\n";
     }
 }

--- a/tests/Double/StubPrototypeDefinition.php
+++ b/tests/Double/StubPrototypeDefinition.php
@@ -25,6 +25,6 @@ class StubPrototypeDefinition extends TestDefinition
     ): string {
         $indent = $this->indent($indentationLevel);
 
-        return "${indent}// This is a dummy definition.\n";
+        return "{$indent}// This is a dummy definition.\n";
     }
 }

--- a/tests/Double/StubSingletonDefinition.php
+++ b/tests/Double/StubSingletonDefinition.php
@@ -38,6 +38,6 @@ class StubSingletonDefinition extends TestDefinition
     ): string {
         $indent = $this->indent($indentationLevel);
 
-        return "${indent}// This is a dummy definition.\n";
+        return "{$indent}// This is a dummy definition.\n";
     }
 }


### PR DESCRIPTION
The `${variable}` styled string interpolation and dynamic property creation became deprecated in PHP 8.2, because of which we get a deprecation warning using Zen. 

This change fixes these issues by replacing `${variable}` to `{$variable}` and checking the existence of the property before assigning it in `AbstractCompiledContainer`