### PR TITLE
Fix a typo in Psr4WildcardHint

### DIFF
--- a/src/Config/Hint/Psr4WildcardHint.php
+++ b/src/Config/Hint/Psr4WildcardHint.php
@@ -85,7 +85,7 @@ class Psr4WildcardHint extends AbstractHint implements WildcardHintInterface
     private function validateNamespace(string $pattern, string $namespace): void
     {
         if (strpos($namespace, "*") !== false) {
-            throw new ContainerException("'$pattern' is an invalid pattern: the namespace part can't contain the asteriks character (*)!");
+            throw new ContainerException("'$pattern' is an invalid pattern: the namespace part can't contain the asterisk character (*)!");
         }
     }
 }


### PR DESCRIPTION
No more ![image](https://github.com/woohoolabs/zen/assets/952007/983d770d-5dfb-45d2-a111-23a537d3c527)
